### PR TITLE
[ADD] jasman_delivery_guide: Create batch delivery guides

### DIFF
--- a/jasman_delivery_guide/__init__.py
+++ b/jasman_delivery_guide/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/jasman_delivery_guide/__manifest__.py
+++ b/jasman_delivery_guide/__manifest__.py
@@ -1,0 +1,27 @@
+{
+    "name": "Jasman: Custom Delivery Guide",
+    "description":
+    """
+        Makes it possible to generate a Delivery Guide
+        (Carta Porte) in a batch delivery order, instead
+        of a single delivery order.
+
+        - Developer: JLOM
+        - Task ID: 3776824
+    """,
+    "category": "Custom Development",
+    "version": "1.0.0",
+    "author": "Odoo Development Services",
+    "maintainer": "Odoo Development Services",
+    "website": "https://www.odoo.com/",
+    "license": "OPL-1",
+    "depends": [
+        "stock_picking_batch",
+        "l10n_mx_edi_stock_extended_30",
+    ],
+    "data": [
+        "data/cfdi_cartaporte_30.xml",
+        "views/stock_picking_views.xml",
+        "views/stock_picking_batch_views.xml",
+    ],
+}

--- a/jasman_delivery_guide/data/cfdi_cartaporte_30.xml
+++ b/jasman_delivery_guide/data/cfdi_cartaporte_30.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="cfdi_cartaporte_30" inherit_id="l10n_mx_edi_stock_30.cfdi_cartaporte_30" primary="True">
+        <xpath expr="//*[name()='cartaporte20:Ubicacion' and @TipoUbicacion='Destino']" position="replace"
+        xmlns:cartaporte20="http://www.sat.gob.mx/CartaPorte20">
+            <t t-foreach="destino" t-as="d">
+                <cartaporte20:Ubicacion
+                    TipoUbicacion="Destino"
+                    t-att-IDUbicacion="d['id_ubicacion']"
+                    t-att-DistanciaRecorrida="d['distancia_recorrida']"
+                    t-att-FechaHoraSalidaLlegada="d['fecha_hora_salida_llegada']"
+                    t-att-RFCRemitenteDestinatario="d['rfc_remitente_destinatario']"
+                    t-att-NumRegIdTrib="d['num_reg_id_trib']"
+                    t-att-ResidenciaFiscal="d['residencia_fiscal']">
+                    <cartaporte20:Domicilio
+                        t-att-Calle="d['domicilio']['calle']"
+                        t-att-CodigoPostal="d['domicilio']['codigo_postal']"
+                        t-att-Estado="d['domicilio']['estado']"
+                        t-att-Pais="d['domicilio']['pais']"
+                        t-att-Municipio="d['domicilio']['municipio']"/>
+                </cartaporte20:Ubicacion>
+            </t>
+        </xpath>
+        <xpath expr="//*[name()='cartaporte20:CantidadTransporta']" position="attributes">
+            <attribute name="t-att-IDOrigen">
+                origen["id_ubicacion"]
+            </attribute>
+            <attribute name="t-att-IDDestino">
+                'DE' + str(move.location_dest_id.id).rjust(6,'0')
+            </attribute>
+        </xpath>
+        <xpath expr="//*[name()='cartaporte20:FiguraTransporte']/t[@t-as='figure']" position="replace"
+        xmlns:cartaporte20="http://www.sat.gob.mx/CartaPorte20">
+            <cartaporte20:TiposFigura
+                t-att-TipoFigura="record.figure_id.type"
+                t-att-RFCFigura="record.figure_id.operator_id.vat"
+                t-att-NumLicencia="record.figure_id.type == '01' and record.figure_id.operator_id.l10n_mx_edi_operator_licence"
+                t-att-NombreFigura="record.figure_id.operator_id.name">
+                <t t-foreach="record.figure_id.part_ids" t-as="part">
+                    <cartaporte20:PartesTransporte t-if="record.figure_id.type in ('02', '03')"
+                        t-att-ParteTransporte="part.code"/>
+                </t>
+            </cartaporte20:TiposFigura>
+        </xpath>
+    </template>
+</odoo>

--- a/jasman_delivery_guide/models/__init__.py
+++ b/jasman_delivery_guide/models/__init__.py
@@ -1,0 +1,4 @@
+from . import l10n_mx_edi_document
+from . import l10n_mx_edi_figure
+from . import stock_picking
+from . import stock_picking_batch

--- a/jasman_delivery_guide/models/l10n_mx_edi_document.py
+++ b/jasman_delivery_guide/models/l10n_mx_edi_document.py
@@ -1,0 +1,95 @@
+from odoo import api, fields, models
+
+
+class L10nMxEdiDocument(models.Model):
+    _inherit = "l10n_mx_edi.document"
+
+    batch_id = fields.Many2one(comodel_name="stock.picking.batch", auto_join=True)
+    state = fields.Selection(
+        selection_add=[
+            ("batch_sent", "Batch Sent"),
+            ("batch_sent_failed", "Batch Sent In Error"),
+            ("batch_cancel", "Batch Cancel"),
+            ("batch_cancel_failed", "Batch Cancelled In Error"),
+        ],
+        ondelete={
+            "batch_sent": "cascade",
+            "batch_sent_failed": "cascade",
+            "batch_cancel": "cascade",
+            "batch_cancel_failed": "cascade",
+        },
+    )
+
+    def _get_cancel_button_map(self):
+        results = super()._get_cancel_button_map()
+        results['batch_sent'] = (
+            'batch_cancel',
+            None,
+            lambda x: x.batch_id._l10n_mx_edi_cfdi_try_cancel(x),
+        )
+        return results
+    
+    def _get_retry_button_map(self):
+        results = super()._get_retry_button_map()
+        results["batch_sent_failed"] = (
+            None,
+            lambda x: x.batch_id.l10n_mx_edi_action_send_batch_delivery_guide(),
+        )
+        results["batch_cancel_failed"] = (
+            None,
+            lambda x: x._action_retry_batch_try_cancel(),
+        )
+        return results
+    
+    def _action_retry_batch_try_cancel(self):
+        self.ensure_one()
+        source_document = self._get_source_document_from_cancel("batch_sent")
+        if source_document:
+            self.batch_id._l10n_mx_edi_cfdi_try_cancel(source_document)
+    
+    @api.model
+    def _create_update_batch_document(self, batch, document_values):
+        if document_values["state"] in ("batch_sent", "batch_cancel"):
+            accept_method_state = f"{document_values['state']}_failed"
+        else:
+            accept_method_state = document_values["state"]
+
+        document = batch.l10n_mx_edi_document_ids._create_update_document(
+            batch,
+            document_values,
+            lambda x: x.state == accept_method_state,
+        )
+
+        batch.l10n_mx_edi_document_ids \
+            .filtered(lambda x: x != document and x.state in ["batch_sent_failed", "batch_cancel_failed"]) \
+            .unlink()
+
+        if document.state in ("batch_sent", "batch_cancel"):
+            batch.l10n_mx_edi_document_ids \
+                .filtered(lambda x: (
+                    x != document
+                    and x.sat_state not in ("valid", "cancelled", "skip")
+                    and x.attachment_uuid == document.attachment_uuid
+                )) \
+                .write({"sat_state": "skip"})
+
+        return document
+    
+    def _update_sat_state(self):
+        # EXTENDS "l10n_mx_edi"
+        sat_results = super()._update_sat_state()
+
+        if sat_results.get("error") and self.batch_id:
+            self.batch_id._message_log(body=sat_results["error"])
+
+        return sat_results
+
+    @api.model
+    def _get_update_sat_status_domains(self):
+        # EXTENDS "l10n_mx_edi"
+        return super()._get_update_sat_status_domains() + [
+            [
+                ("state", "in", ("batch_sent", "batch_cancel")),
+                ("sat_state", "not in", ("valid", "cancelled", "skip")),
+            ],
+        ]

--- a/jasman_delivery_guide/models/l10n_mx_edi_figure.py
+++ b/jasman_delivery_guide/models/l10n_mx_edi_figure.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class MxEdiFigure(models.Model):
+    _inherit = "l10n_mx_edi.figure"
+
+    name = fields.Char(related="operator_id.name")

--- a/jasman_delivery_guide/models/stock_picking.py
+++ b/jasman_delivery_guide/models/stock_picking.py
@@ -1,0 +1,30 @@
+from odoo import api, fields, models
+
+
+class Picking(models.Model):
+    _inherit = "stock.picking"
+
+    l10n_mx_edi_transport_type = fields.Selection(
+        compute="_compute_delivery_guide_fields",
+        store=True,
+        readonly=False,
+    )
+    l10n_mx_edi_vehicle_id = fields.Many2one("l10n_mx_edi.vehicle",
+        compute="_compute_delivery_guide_fields",
+        store=True,
+        readonly=False,
+    )
+
+    @api.depends("batch_id.l10n_mx_edi_transport_type",
+                 "batch_id.l10n_mx_edi_vehicle_id")
+    def _compute_delivery_guide_fields(self):
+        for picking in self:
+            picking.l10n_mx_edi_transport_type = picking.batch_id.l10n_mx_edi_transport_type
+            picking.l10n_mx_edi_vehicle_id = picking.batch_id.l10n_mx_edi_vehicle_id
+
+    def _l10n_mx_edi_cfdi_check_picking_config(self):
+        # EXTENDS l10n_mx_edi_stock
+        self.ensure_one()
+        if not self.l10n_mx_edi_distance:
+            self.l10n_mx_edi_distance = self.batch_id.l10n_mx_edi_distance
+        return super()._l10n_mx_edi_cfdi_check_picking_config()

--- a/jasman_delivery_guide/models/stock_picking_batch.py
+++ b/jasman_delivery_guide/models/stock_picking_batch.py
@@ -1,0 +1,391 @@
+import uuid
+from datetime import datetime
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+from odoo.osv import expression
+
+
+class StockPickingBatch(models.Model):
+    _inherit = "stock.picking.batch"
+
+    country_code = fields.Char(related="company_id.account_fiscal_country_id.code")
+    l10n_mx_edi_document_ids = fields.One2many(
+        comodel_name="l10n_mx_edi.document",
+        inverse_name="batch_id",
+        copy=False,
+        readonly=True,
+    )
+    l10n_mx_edi_transport_type = fields.Selection(
+        selection=[
+            ("00", "No Federal Highways"),
+            ("01", "Federal Transport"),
+        ],
+        string="Transport Type",
+        copy=False
+    )
+    l10n_mx_edi_vehicle_id = fields.Many2one("l10n_mx_edi.vehicle",
+        string="Vehicle Setup",
+        ondelete="restrict",
+        copy=False
+    )
+    l10n_mx_edi_distance = fields.Integer(
+        "Distance to Destination (KM)",
+        compute="_compute_l10n_mx_edi_distance",
+    )
+    l10n_mx_edi_cfdi_origin = fields.Char(
+        string="CFDI Origin",
+        copy=False,
+        help="Specify the existing Fiscal Folios to replace. Prepend with '04|'",
+    )
+    l10n_mx_edi_is_cfdi_needed = fields.Boolean(
+        compute="_compute_l10n_mx_edi_is_cfdi_needed",
+        store=True,
+    )
+    l10n_mx_edi_cfdi_state = fields.Selection(
+        string="CFDI status",
+        selection=[
+            ("sent", "Signed"),
+            ("cancel", "Cancelled"),
+        ],
+        store=True,
+        copy=False,
+        tracking=True,
+        compute="_compute_l10n_mx_edi_cfdi_state_and_attachment",
+    )
+    l10n_mx_edi_cfdi_sat_state = fields.Selection(
+        string="SAT status",
+        selection=[
+            ("valid", "Validated"),
+            ("not_found", "Not Found"),
+            ("not_defined", "Not Defined"),
+            ("cancelled", "Cancelled"),
+            ("error", "Error"),
+        ],
+        store=True,
+        copy=False,
+        tracking=True,
+        compute="_compute_l10n_mx_edi_cfdi_state_and_attachment",
+    )
+    l10n_mx_edi_cfdi_attachment_id = fields.Many2one(
+        comodel_name="ir.attachment",
+        store=True,
+        copy=False,
+        compute="_compute_l10n_mx_edi_cfdi_state_and_attachment",
+    )
+    l10n_mx_edi_update_sat_needed = fields.Boolean(compute="_compute_l10n_mx_edi_update_sat_needed")
+    l10n_mx_edi_idccp = fields.Char(
+        string="IdCCP",
+        help="Additional UUID for the Delivery Guide.",
+        compute="_compute_l10n_mx_edi_idccp",
+    )
+    l10n_mx_edi_external_trade = fields.Char(compute="_compute_batch_contact")
+    l10n_mx_edi_cfdi_uuid = fields.Char(
+        string="Fiscal Folio",
+        compute="_compute_l10n_mx_edi_cfdi_uuid",
+        copy=False,
+        store=True,
+        help="Folio in electronic invoice, is returned by SAT when send to stamp.",
+    )
+    is_delivery_guide_possible = fields.Boolean(compute="_compute_is_delivery_guide_possible")
+    figure_ids = fields.One2many(related="l10n_mx_edi_vehicle_id.figure_ids")
+    figure_id = fields.Many2one("l10n_mx_edi.figure", 
+        string="Vehicle Operator",
+        domain="""[("id", "in", figure_ids), ("type", "=", "01")]""")
+    effective_date = fields.Datetime("Date of Batch", copy=False, readonly=True, help="Date at which the batch has been processed or cancelled.")
+    batch_contact = fields.Many2one("res.partner", compute="_compute_batch_contact")
+
+    def action_done(self):
+        res = super().action_done()
+        self.effective_date = datetime.today()
+        return res
+    
+    @api.depends("company_id", "state", "picking_type_code")
+    def _compute_l10n_mx_edi_is_cfdi_needed(self):
+        for batch in self:
+            batch.l10n_mx_edi_is_cfdi_needed = \
+                batch.country_code == "MX" \
+                and batch.state == "done" \
+                and batch.picking_type_code == "outgoing"
+            
+    @api.depends("l10n_mx_edi_document_ids.state", "l10n_mx_edi_document_ids.sat_state")
+    def _compute_l10n_mx_edi_cfdi_state_and_attachment(self):
+        for batch in self:
+            batch.l10n_mx_edi_cfdi_sat_state = None
+            batch.l10n_mx_edi_cfdi_state = None
+            batch.l10n_mx_edi_cfdi_attachment_id = None
+            for doc in batch.l10n_mx_edi_document_ids.sorted():
+                if doc.state == "batch_sent":
+                    batch.l10n_mx_edi_cfdi_sat_state = doc.sat_state
+                    batch.l10n_mx_edi_cfdi_state = "sent"
+                    batch.l10n_mx_edi_cfdi_attachment_id = doc.attachment_id
+                    break
+                elif doc.state == "batch_cancel":
+                    batch.l10n_mx_edi_cfdi_sat_state = doc.sat_state
+                    batch.l10n_mx_edi_cfdi_state = "cancel"
+                    batch.l10n_mx_edi_cfdi_attachment_id = doc.attachment_id
+                    break
+    
+    @api.depends("l10n_mx_edi_document_ids.state")
+    def _compute_l10n_mx_edi_update_sat_needed(self):
+        for batch in self:
+            batch.l10n_mx_edi_update_sat_needed = bool(
+                batch.l10n_mx_edi_document_ids.filtered_domain(
+                    expression.OR(self.env["l10n_mx_edi.document"]._get_update_sat_status_domains())
+                )
+            )
+
+    @api.depends("l10n_mx_edi_cfdi_attachment_id")
+    def _compute_l10n_mx_edi_cfdi_uuid(self):
+        for batch in self:
+            if batch.l10n_mx_edi_cfdi_attachment_id:
+                cfdi_infos = self.env["l10n_mx_edi.document"]._decode_cfdi_attachment(batch.l10n_mx_edi_cfdi_attachment_id.raw)
+                batch.l10n_mx_edi_cfdi_uuid = cfdi_infos.get("uuid")
+            else:
+                batch.l10n_mx_edi_cfdi_uuid = None
+    
+    @api.depends("l10n_mx_edi_is_cfdi_needed")
+    def _compute_l10n_mx_edi_idccp(self):
+        for batch in self:
+            if batch.l10n_mx_edi_is_cfdi_needed and not batch.l10n_mx_edi_idccp:
+                # The IdCCP must be a 36 characters long RFC 4122 identifier starting with "CCC".
+                batch.l10n_mx_edi_idccp = f"CCC{str(uuid.uuid4())[3:]}"
+            else:
+                batch.l10n_mx_edi_idccp = False
+
+    @api.depends("picking_ids.l10n_mx_edi_distance")
+    def _compute_l10n_mx_edi_distance(self):
+        for batch in self:
+            batch.l10n_mx_edi_distance = sum(batch.picking_ids.mapped("l10n_mx_edi_distance"))
+    
+    @api.depends("picking_ids.partner_id")
+    def _compute_batch_contact(self):
+        for batch in self:
+            if len(batch.picking_ids.partner_id) == 1:
+                batch.batch_contact = batch.picking_ids.partner_id
+            elif len(batch.picking_ids.partner_id.parent_id) == 1 \
+                 and all([p.parent_id for p in batch.picking_ids.partner_id]):
+                batch.batch_contact = batch.picking_ids.partner_id.parent_id
+            else:
+                batch.batch_contact = False
+            batch.l10n_mx_edi_external_trade = batch.batch_contact.country_code != "MX"
+    
+    @api.depends("picking_ids")
+    def _compute_is_delivery_guide_possible(self):
+        for batch in self:
+            batch.is_delivery_guide_possible = batch.state == "done" \
+                and self.picking_type_code == "outgoing" \
+                and self.batch_contact
+    
+    @api.model
+    def _l10n_mx_edi_add_domicilio_cfdi_values(self, cfdi_values, partner):
+        cfdi_values["domicilio"] = {
+            "calle": partner.street,
+            "codigo_postal": partner.zip,
+            "estado": partner.state_id.code,
+            "pais": partner.country_id.l10n_mx_edi_code,
+            "municipio": partner.city_id.l10n_mx_edi_code or partner.city,
+        }
+    
+    def _l10n_mx_edi_add_batch_cfdi_values(self, cfdi_values):
+        self.ensure_one()
+        company = cfdi_values["company"]
+
+        if self.picking_type_id.warehouse_id.partner_id:
+            cfdi_values["issued_address"] = self.picking_type_id.warehouse_id.partner_id
+        issued_address = cfdi_values["issued_address"]
+
+        self.env["l10n_mx_edi.document"]._add_base_cfdi_values(cfdi_values)
+        self.env["l10n_mx_edi.document"]._add_currency_cfdi_values(cfdi_values, company.currency_id)
+        self.env["l10n_mx_edi.document"]._add_document_name_cfdi_values(cfdi_values, self.name)
+        self.env["l10n_mx_edi.document"]._add_document_origin_cfdi_values(cfdi_values, self.l10n_mx_edi_cfdi_origin)
+        self.env["l10n_mx_edi.document"]._add_customer_cfdi_values(cfdi_values, self.batch_contact)
+
+        mx_tz = issued_address._l10n_mx_edi_get_cfdi_timezone()
+        date_fmt = "%Y-%m-%dT%H:%M:%S"
+
+        cfdi_values.update({
+            "record": self,
+            "cfdi_date": self.effective_date.astimezone(mx_tz).strftime(date_fmt),
+            "scheduled_date": self.scheduled_date.astimezone(mx_tz).strftime(date_fmt),
+            "lugar_expedicion": issued_address.zip,
+            "moves": self.move_ids.filtered(lambda ml: ml.quantity > 0),
+            "weight_uom": self.env["product.template"]._get_weight_uom_id_from_ir_config_parameter(),
+        })
+
+        cfdi_values["idccp"] = self.l10n_mx_edi_idccp
+
+        if self.l10n_mx_edi_vehicle_id:
+            cfdi_values["peso_bruto_vehicular"] = self.l10n_mx_edi_vehicle_id.gross_vehicle_weight
+        else:
+            cfdi_values["peso_bruto_vehicular"] = None
+
+        warehouse_partner = self.picking_type_id.warehouse_id.partner_id
+        warehouse_location = self.picking_type_id.warehouse_id.lot_stock_id \
+                             or self.picking_type_id.default_location_src_id
+        receptor = cfdi_values["receptor"]
+        emisor = cfdi_values["emisor"]
+
+        cfdi_values["origen"] = {
+            "id_ubicacion": f"OR{str(warehouse_location.id).rjust(6, '0')}",
+            "fecha_hora_salida_llegada": cfdi_values["cfdi_date"],
+            "num_reg_id_trib": None,
+            "residencia_fiscal": None,
+        }
+        cfdi_values["destino"] = [{
+            "id_ubicacion": f"DE{str(picking.location_dest_id.id).rjust(6, '0')}",
+            "fecha_hora_salida_llegada": picking.scheduled_date.astimezone(mx_tz).strftime(date_fmt),
+            "num_reg_id_trib": None,
+            "residencia_fiscal": None,
+            "distancia_recorrida": picking.l10n_mx_edi_distance,
+        } for picking in self.picking_ids]
+
+        if warehouse_partner.country_id.l10n_mx_edi_code != "MEX":
+            cfdi_values["origen"]["rfc_remitente_destinatario"] = "XEXX010101000"
+            cfdi_values["origen"]["num_reg_id_trib"] = emisor["supplier"].vat
+            cfdi_values["origen"]["residencia_fiscal"] = warehouse_partner.country_id.l10n_mx_edi_code
+        else:
+            cfdi_values["origen"]["rfc_remitente_destinatario"] = emisor["rfc"]
+        self._l10n_mx_edi_add_domicilio_cfdi_values(cfdi_values["origen"], warehouse_partner)
+        
+        for picking in cfdi_values["destino"]:
+            picking["rfc_remitente_destinatario"] = receptor["rfc"]
+            if self.l10n_mx_edi_external_trade:
+                picking["num_reg_id_trib"] = receptor["customer"].vat
+                picking["residencia_fiscal"] = receptor["customer"].country_id.l10n_mx_edi_code
+            self._l10n_mx_edi_add_domicilio_cfdi_values(picking, receptor["customer"])
+    
+    def _l10n_mx_edi_cfdi_document_sent_failed(self, error, cfdi_filename=None, cfdi_str=None):
+        self.ensure_one()
+
+        document_values = {
+            "batch_id": self.id,
+            "state": "batch_sent_failed",
+            "sat_state": None,
+            "message": error,
+        }
+        if cfdi_filename and cfdi_str:
+            document_values["attachment_id"] = {
+                "name": cfdi_filename,
+                "raw": cfdi_str,
+            }
+        return self.env["l10n_mx_edi.document"]._create_update_batch_document(self, document_values)
+    
+    def _l10n_mx_edi_cfdi_document_sent(self, cfdi_filename, cfdi_str):
+        self.ensure_one()
+
+        document_values = {
+            "batch_id": self.id,
+            "state": "batch_sent",
+            "sat_state": "not_defined",
+            "message": None,
+            "attachment_id": {
+                "name": cfdi_filename,
+                "raw": cfdi_str,
+                "res_model": self._name,
+                "res_id": self.id,
+                "description": "CFDI",
+            },
+        }
+        return self.env["l10n_mx_edi.document"]._create_update_batch_document(self, document_values)
+    
+    @api.model
+    def _l10n_mx_edi_prepare_batch_cfdi_template(self):
+        return "jasman_delivery_guide.cfdi_cartaporte_30"
+    
+    def l10n_mx_edi_action_send_batch_delivery_guide(self):
+        self.ensure_one()
+        if not self.is_delivery_guide_possible:
+            raise UserError(_("Operation type must be 'Delivery' and "
+                              "batch must be in stage 'Done' to "
+                              "generate the Delivery Guide"))
+        
+        for picking in self.picking_ids:
+            errors = picking._l10n_mx_edi_cfdi_check_external_trade_config() \
+                   + picking._l10n_mx_edi_cfdi_check_picking_config()
+            if errors:
+                errors.insert(0, picking.name)
+                self._l10n_mx_edi_cfdi_document_sent_failed("\n".join(errors))
+                return
+            
+        self.env["l10n_mx_edi.document"]._with_locked_records(self)
+        
+        def on_populate(cfdi_values):
+            self._l10n_mx_edi_add_batch_cfdi_values(cfdi_values)
+
+        def on_failure(error, cfdi_filename=None, cfdi_str=None):
+            self._l10n_mx_edi_cfdi_document_sent_failed(error, cfdi_filename=cfdi_filename, cfdi_str=cfdi_str)
+
+        def on_success(_cfdi_values, cfdi_filename, cfdi_str, populate_return=None):
+            document = self._l10n_mx_edi_cfdi_document_sent(cfdi_filename, cfdi_str)
+            self.message_post(
+                body=_("The CFDI document was successfully created and signed by the government."),
+                attachment_ids=document.attachment_id.ids,
+            )
+
+        qweb_template = self._l10n_mx_edi_prepare_batch_cfdi_template()
+        cfdi_filename = f"CFDI_DeliveryGuide_{self.name}.xml".replace("/", "")
+        self.env["l10n_mx_edi.document"]._send_api(
+            self.company_id,
+            qweb_template,
+            cfdi_filename,
+            on_populate,
+            on_failure,
+            on_success,
+        )
+
+    def _l10n_mx_edi_cfdi_document_cancel_failed(self, error, cfdi, cancel_reason):
+        self.ensure_one()
+
+        document_values = {
+            "batch_id": self.id,
+            "state": "batch_cancel_failed",
+            "sat_state": None,
+            "message": error,
+            "attachment_id": cfdi.attachment_id.id,
+            "cancellation_reason": cancel_reason,
+        }
+        return self.env["l10n_mx_edi.document"]._create_update_batch_document(self, document_values)
+    
+    def _l10n_mx_edi_cfdi_document_cancel(self, cfdi, cancel_reason):
+        self.ensure_one()
+
+        document_values = {
+            "batch_id": self.id,
+            "state": "batch_cancel",
+            "sat_state": "not_defined",
+            "message": None,
+            "attachment_id": cfdi.attachment_id.id,
+            "cancellation_reason": cancel_reason,
+        }
+        return self.env["l10n_mx_edi.document"]._create_update_batch_document(self, document_values)
+    
+    def _l10n_mx_edi_cfdi_try_cancel(self, document):
+        self.ensure_one()
+        if self.l10n_mx_edi_cfdi_state != "sent":
+            return
+
+        self.env["l10n_mx_edi.document"]._with_locked_records(self)
+
+        substitution_doc = document._get_substitution_document()
+        cancel_uuid = substitution_doc.attachment_uuid
+        cancel_reason = "01" if cancel_uuid else "02"
+
+        def on_failure(error):
+            self._l10n_mx_edi_cfdi_document_cancel_failed(error, document, cancel_reason)
+
+        def on_success():
+            self._l10n_mx_edi_cfdi_document_cancel(document, cancel_reason)
+            self.l10n_mx_edi_cfdi_origin = f"04|{self.l10n_mx_edi_cfdi_uuid}"
+            self.message_post(body=_("The CFDI document has been successfully cancelled."))
+
+        document._cancel_api(self.company_id, cancel_reason, on_failure, on_success)
+    
+    def l10n_mx_edi_cfdi_try_cancel(self):
+        self.ensure_one()
+        source_document = self.l10n_mx_edi_document_ids.filtered(lambda x: x.state == "batch_sent")[:1]
+        self._l10n_mx_edi_cfdi_try_cancel(source_document)
+
+    def l10n_mx_edi_cfdi_try_sat(self):
+        self.ensure_one()
+        self.env["l10n_mx_edi.document"]._fetch_and_update_sat_status(extra_domain=[("batch_id", "=", self.id)])

--- a/jasman_delivery_guide/tests/__init__.py
+++ b/jasman_delivery_guide/tests/__init__.py
@@ -1,0 +1,3 @@
+from . import common
+from . import test_cfdi_batch
+from . import test_cfdi_batch_documents

--- a/jasman_delivery_guide/tests/common.py
+++ b/jasman_delivery_guide/tests/common.py
@@ -1,0 +1,137 @@
+from odoo.addons.l10n_mx_edi_stock_extended_30.tests.common import TestMXEdiStockCommon
+
+
+class TestJasmanDeliveryGuideCommon(TestMXEdiStockCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref="mx"):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.company_data["company"].write({
+            "l10n_mx_edi_pac": "solfact",
+        })
+
+        cls.product_c.write({
+            "name": "Lámpara de oficina",
+            "unspsc_code_id": cls.env.ref("product_unspsc.unspsc_code_56101900").id,
+        })
+
+        cls.vehicle_pedro.write({
+            "gross_vehicle_weight": 2.0,
+        })
+        
+        cls.customer_location_2 = cls.env["stock.location"].create({
+            "name": "Test Customers",
+            "location_id": cls.env.ref("stock.stock_location_locations_partner").id,
+            "usage": "customer",
+        })
+        cls.internal_location_2 = cls.env["stock.location"].create({
+            "name": "Stock 2",
+            "location_id": cls.env.ref("stock.stock_location_locations").id,
+        })
+
+        cls.partner_mx_chih = cls.env["res.partner"].create({
+            "name": "TEST_CHIH",
+            "street": "Street Calle",
+            "city": "Hidalgo del Parral",
+            "country_id": cls.env.ref("base.mx").id,
+            "state_id": cls.env.ref("base.state_mx_chih").id,
+            "zip": "33826",
+            "vat": "ICV060329BY0",
+            "parent_id": cls.partner_mx.id,
+        })
+        cls.partner_mx_oax = cls.env["res.partner"].create({
+            "name": "TEST_OAX",
+            "street": "Street Calle",
+            "city": "Oaxaca de Juárez",
+            "country_id": cls.env.ref("base.mx").id,
+            "state_id": cls.env.ref("base.state_mx_oax").id,
+            "zip": "68025",
+            "vat": "ICV060329BY0",
+            "parent_id": cls.partner_mx.id,
+        })
+
+    def _create_picking(self, warehouse, picking_vals, move_vals):
+        picking = self.env["stock.picking"].create(picking_vals)
+
+        self.env["stock.move"].create({
+            "picking_id": picking.id,
+            **move_vals,
+        })
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_c, 
+            self.env["stock.location"].browse(move_vals["location_id"]), 
+            10.0)
+        picking.action_confirm()
+        picking.action_assign()
+        picking.move_ids[0].move_line_ids[0].quantity = 10
+        picking.move_ids[0].picked = True
+        return picking
+    
+    def _create_batch(self, warehouse, picking_vals_list=None, move_vals_list=None):
+        # By default, use values that lead to
+        # a successful result (happy path)
+        if not picking_vals_list:
+            picking_vals_list = [
+                {
+                    "location_id": warehouse.lot_stock_id.id,
+                    "location_dest_id": self.customer_location.id,
+                    "picking_type_id": warehouse.out_type_id.id,
+                    "partner_id": self.partner_mx_chih.id,
+                    "l10n_mx_edi_transport_type": "01",
+                    "l10n_mx_edi_vehicle_id": self.vehicle_pedro.id,
+                    "l10n_mx_edi_distance": 60,
+                    "state": "draft",
+                },
+                {
+                    "location_id": self.internal_location_2.id,
+                    "location_dest_id": self.customer_location_2.id,
+                    "picking_type_id": warehouse.out_type_id.id,
+                    "partner_id": self.partner_mx_oax.id,
+                    "l10n_mx_edi_transport_type": "01",
+                    "l10n_mx_edi_vehicle_id": self.vehicle_pedro.id,
+                    "l10n_mx_edi_distance": 40,
+                    "state": "draft",
+                },
+            ]
+        if not move_vals_list:
+            move_vals_list = [
+                {
+                    "name": self.product_c.name,
+                    "product_id": self.product_c.id,
+                    "product_uom_qty": 3,
+                    "product_uom": self.product_c.uom_id.id,
+                    "location_id": warehouse.lot_stock_id.id,
+                    "location_dest_id": self.customer_location.id,
+                    "state": "confirmed",
+                    "description_picking": self.product_c.name,
+                    "company_id": warehouse.company_id.id,
+                },
+                {
+                    "name": self.product_c.name,
+                    "product_id": self.product_c.id,
+                    "product_uom_qty": 2,
+                    "product_uom": self.product_c.uom_id.id,
+                    "location_id": self.internal_location_2.id,
+                    "location_dest_id": self.customer_location_2.id,
+                    "state": "confirmed",
+                    "description_picking": self.product_c.name,
+                    "company_id": warehouse.company_id.id,
+                },
+            ]
+        pickings = [self._create_picking(warehouse, picking_vals=p[0], move_vals=p[1])
+                    for p in zip(picking_vals_list, move_vals_list)]
+        return self.env['stock.picking.batch'].create({
+            'name': 'BATCH/00001',
+            'company_id': self.env.company.id,
+            'picking_ids': [p.id for p in pickings],
+            'l10n_mx_edi_transport_type': '01',
+            'l10n_mx_edi_vehicle_id': self.vehicle_pedro.id,
+            'figure_id': self.vehicle_pedro.figure_ids[0].id,
+        })
+    
+    def _assert_batch_cfdi(self, batch, filename):
+        document = batch.l10n_mx_edi_document_ids \
+            .filtered(lambda x: x.state == 'batch_sent')[:1]
+        self._assert_document_cfdi(document, filename)

--- a/jasman_delivery_guide/tests/test_cfdi_batch.py
+++ b/jasman_delivery_guide/tests/test_cfdi_batch.py
@@ -1,0 +1,25 @@
+from freezegun import freeze_time
+
+from odoo.tests import tagged
+
+from .common import TestJasmanDeliveryGuideCommon
+
+
+@tagged('jasman', 'post_install_l10n', 'post_install', '-at_install')
+class TestCFDIJasmanBatchXml(TestJasmanDeliveryGuideCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='mx'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.env.company.partner_id.city_id = cls.env.ref('l10n_mx_edi_extended.res_city_mx_chh_032').id
+
+    @freeze_time('2017-01-01')
+    def test_delivery_guide_batch(self):
+        warehouse = self._create_warehouse()
+        batch = self._create_batch(warehouse)
+        batch.action_done()
+
+        with self.with_mocked_pac_sign_success():
+            batch.l10n_mx_edi_action_send_batch_delivery_guide()
+
+        self._assert_batch_cfdi(batch, 'test_delivery_guide_batch')

--- a/jasman_delivery_guide/tests/test_cfdi_batch_documents.py
+++ b/jasman_delivery_guide/tests/test_cfdi_batch_documents.py
@@ -1,0 +1,157 @@
+from freezegun import freeze_time
+
+from odoo import fields
+from odoo.tests import tagged
+
+from .common import TestJasmanDeliveryGuideCommon
+
+
+@tagged('jasman', 'post_install_l10n', 'post_install', '-at_install')
+class TestCFDIJasmanBatchWorkflow(TestJasmanDeliveryGuideCommon):
+
+    def test_batch_workflow(self):
+        warehouse = self._create_warehouse()
+        batch = self._create_batch(warehouse)
+        batch.action_done()
+
+        # No pac found.
+        self.env.company.l10n_mx_edi_pac = None
+        with freeze_time('2017-01-05'):
+            batch.l10n_mx_edi_action_send_batch_delivery_guide()
+        self.assertRecordValues(batch.l10n_mx_edi_document_ids, [
+            {
+                'datetime': fields.Datetime.from_string('2017-01-05 00:00:00'),
+                'message': "No PAC specified.",
+                'state': 'batch_sent_failed',
+                'sat_state': False,
+                'cancellation_reason': False,
+                'cancel_button_needed': False,
+                'retry_button_needed': True,
+            },
+        ])
+        self.assertRecordValues(batch, [{'l10n_mx_edi_cfdi_state': None}])
+
+        # Set back the PAC but make it raising an error.
+        self.env.company.l10n_mx_edi_pac = 'solfact'
+        with freeze_time('2017-01-06'), self.with_mocked_pac_sign_error():
+            batch.l10n_mx_edi_action_send_batch_delivery_guide()
+        self.assertRecordValues(batch.l10n_mx_edi_document_ids, [
+            {
+                'datetime': fields.Datetime.from_string('2017-01-06 00:00:00'),
+                'message': "turlututu",
+                'state': 'batch_sent_failed',
+                'sat_state': False,
+                'cancellation_reason': False,
+                'cancel_button_needed': False,
+                'retry_button_needed': True,
+            },
+        ])
+        self.assertRecordValues(batch, [{'l10n_mx_edi_cfdi_state': None}])
+
+        # The failing attachment remains accessible for the user.
+        self.assertTrue(batch.l10n_mx_edi_document_ids.attachment_id)
+
+        # Sign.
+        with freeze_time('2017-01-07'), self.with_mocked_pac_sign_success():
+            batch.l10n_mx_edi_document_ids.action_retry()
+        sent_doc_values = {
+            'datetime': fields.Datetime.from_string('2017-01-07 00:00:00'),
+            'message': False,
+            'state': 'batch_sent',
+            'sat_state': 'not_defined',
+            'cancellation_reason': False,
+            'cancel_button_needed': True,
+            'retry_button_needed': False,
+        }
+        self.assertRecordValues(batch.l10n_mx_edi_document_ids, [sent_doc_values])
+        self.assertTrue(batch.l10n_mx_edi_cfdi_attachment_id)
+        self.assertTrue(batch.l10n_mx_edi_document_ids.attachment_id)
+        self.assertRecordValues(batch, [{'l10n_mx_edi_cfdi_state': 'sent'}])
+
+        # Cancel failed.
+        self.env.company.l10n_mx_edi_pac = None
+        with freeze_time('2017-02-01'):
+            batch._l10n_mx_edi_cfdi_try_cancel(batch.l10n_mx_edi_document_ids)
+        self.assertRecordValues(batch.l10n_mx_edi_document_ids.sorted(), [
+            {
+                'datetime': fields.Datetime.from_string('2017-02-01 00:00:00'),
+                'message': "No PAC specified.",
+                'state': 'batch_cancel_failed',
+                'sat_state': False,
+                'cancellation_reason': '02',
+                'cancel_button_needed': False,
+                'retry_button_needed': True,
+            },
+            sent_doc_values,
+        ])
+
+        # Set back the PAC but make it raising an error.
+        self.env.company.l10n_mx_edi_pac = 'solfact'
+        with freeze_time('2017-02-06'), self.with_mocked_pac_cancel_error():
+            batch.l10n_mx_edi_document_ids.sorted()[0].action_retry()
+        self.assertRecordValues(batch.l10n_mx_edi_document_ids.sorted(), [
+            {
+                'datetime': fields.Datetime.from_string('2017-02-06 00:00:00'),
+                'message': "turlututu",
+                'state': 'batch_cancel_failed',
+                'sat_state': False,
+                'cancellation_reason': '02',
+                'cancel_button_needed': False,
+                'retry_button_needed': True,
+            },
+            sent_doc_values,
+        ])
+
+        # Cancel
+        with freeze_time('2017-02-07'), self.with_mocked_pac_cancel_success():
+            batch.l10n_mx_edi_document_ids.sorted()[0].action_retry()
+
+        batch.l10n_mx_edi_document_ids.invalidate_recordset(fnames=['cancel_button_needed'])
+        sent_doc_values['cancel_button_needed'] = False
+        sent_doc_values['sat_state'] = 'skip'
+
+        cancel_doc_values = {
+            'datetime': fields.Datetime.from_string('2017-02-07 00:00:00'),
+            'message': False,
+            'state': 'batch_cancel',
+            'sat_state': 'not_defined',
+            'cancellation_reason': '02',
+            'cancel_button_needed': False,
+            'retry_button_needed': False,
+        }
+        self.assertRecordValues(batch.l10n_mx_edi_document_ids.sorted(), [
+            cancel_doc_values,
+            sent_doc_values,
+        ])
+        self.assertRecordValues(batch, [{'l10n_mx_edi_cfdi_state': 'cancel'}])
+
+        # Sign again.
+        with freeze_time('2017-03-10'), self.with_mocked_pac_sign_success():
+            batch.l10n_mx_edi_action_send_batch_delivery_guide()
+        sent_doc_values2 = {
+            'datetime': fields.Datetime.from_string('2017-03-10 00:00:00'),
+            'message': False,
+            'state': 'batch_sent',
+            'sat_state': 'not_defined',
+            'cancellation_reason': False,
+            'cancel_button_needed': True,
+            'retry_button_needed': False,
+        }
+        self.assertRecordValues(batch.l10n_mx_edi_document_ids.sorted(), [
+            sent_doc_values2,
+            cancel_doc_values,
+            sent_doc_values,
+        ])
+        self.assertRecordValues(batch, [{'l10n_mx_edi_cfdi_state': 'sent'}])
+
+        # Sat.
+        with freeze_time('2017-04-01'), self.with_mocked_sat_call(lambda x: 'valid' if x['state'] == 'batch_sent' else 'cancelled'):
+            batch.l10n_mx_edi_cfdi_try_sat()
+        sent_doc_values2['sat_state'] = 'valid'
+        cancel_doc_values['sat_state'] = 'cancelled'
+        self.assertRecordValues(batch.l10n_mx_edi_document_ids.sorted(), [
+            sent_doc_values2,
+            cancel_doc_values,
+            sent_doc_values,
+        ])
+        self.assertRecordValues(batch, [{'l10n_mx_edi_cfdi_state': 'sent'}])

--- a/jasman_delivery_guide/tests/test_files/test_delivery_guide_batch.xml
+++ b/jasman_delivery_guide/tests/test_files/test_delivery_guide_batch.xml
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cfdi="http://www.sat.gob.mx/cfd/4" xmlns:cartaporte30="http://www.sat.gob.mx/CartaPorte30" Moneda="XXX" Serie="BATCH/" SubTotal="0" TipoDeComprobante="T" Total="0" Version="4.0" Exportacion="01" xsi:schemaLocation="http://www.sat.gob.mx/cfd/4 http://www.sat.gob.mx/sitio_internet/cfd/4/cfdv40.xsd http://www.sat.gob.mx/CartaPorte30 http://www.sat.gob.mx/sitio_internet/cfd/CartaPorte/CartaPorte30.xsd http://www.sat.gob.mx/sitio_internet/cfd/CartaPorte30/CartaPorte30.xsd" Fecha="___ignore___" Folio="___ignore___" NoCertificado="___ignore___" Certificado="___ignore___" LugarExpedicion="20928" Sello="___ignore___">
+	<cfdi:Emisor Nombre="ESCUELA KEMPER URGATE" RegimenFiscal="601" Rfc="EKU9003173C9"/>
+	<cfdi:Receptor UsoCFDI="S01" Nombre="ESCUELA KEMPER URGATE" Rfc="EKU9003173C9" DomicilioFiscalReceptor="20928" RegimenFiscalReceptor="601"/>
+	<cfdi:Conceptos>
+		<cfdi:Concepto Importe="0.00" ValorUnitario="0.00" ObjetoImp="01" NoIdentificacion="01" Cantidad="10.000000" ClaveProdServ="56101900" ClaveUnidad="H87" Descripcion="Lámpara de oficina" Unidad="Units">
+		</cfdi:Concepto>
+		<cfdi:Concepto Importe="0.00" ValorUnitario="0.00" ObjetoImp="01" NoIdentificacion="01" Cantidad="10.000000" ClaveProdServ="56101900" ClaveUnidad="H87" Descripcion="Lámpara de oficina" Unidad="Units">
+		</cfdi:Concepto>
+	</cfdi:Conceptos>
+	<cfdi:Complemento>
+		<cartaporte30:CartaPorte Version="3.0" TranspInternac="No" TotalDistRec="100" IdCCP="___ignore___">
+			<cartaporte30:Ubicaciones>
+				<cartaporte30:Ubicacion TipoUbicacion="Origen" IDUbicacion="___ignore___" FechaHoraSalidaLlegada="___ignore___" RFCRemitenteDestinatario="EKU9003173C9">
+					<cartaporte30:Domicilio Calle="Campobasso Norte 3206 - 9000" CodigoPostal="20928" Estado="AGU" Pais="MEX" Municipio="032"/>
+				</cartaporte30:Ubicacion>
+				<cartaporte30:Ubicacion TipoUbicacion="Destino" IDUbicacion="___ignore___" DistanciaRecorrida="40" FechaHoraSalidaLlegada="___ignore___" RFCRemitenteDestinatario="ICV060329BY0">
+					<cartaporte30:Domicilio Calle="Street Calle" CodigoPostal="33826" Estado="CHH" Pais="MEX" Municipio="Hidalgo del Parral"/>
+				</cartaporte30:Ubicacion>
+				<cartaporte30:Ubicacion TipoUbicacion="Destino" IDUbicacion="___ignore___" DistanciaRecorrida="60" FechaHoraSalidaLlegada="___ignore___" RFCRemitenteDestinatario="ICV060329BY0">
+					<cartaporte30:Domicilio Calle="Street Calle" CodigoPostal="33826" Estado="CHH" Pais="MEX" Municipio="Hidalgo del Parral"/>
+				</cartaporte30:Ubicacion>
+			</cartaporte30:Ubicaciones>
+			<cartaporte30:Mercancias NumTotalMercancias="2" PesoBrutoTotal="5.000" UnidadPeso="KGM">
+				<cartaporte30:Mercancia BienesTransp="56101900" Cantidad="10.000000" ClaveUnidad="H87" Descripcion="Lámpara de oficina" PesoEnKg="2.000">
+					<cartaporte30:CantidadTransporta Cantidad="10.000000" IDOrigen="___ignore___" IDDestino="___ignore___"/>
+				</cartaporte30:Mercancia>
+				<cartaporte30:Mercancia BienesTransp="56101900" Cantidad="10.000000" ClaveUnidad="H87" Descripcion="Lámpara de oficina" PesoEnKg="3.000">
+					<cartaporte30:CantidadTransporta Cantidad="10.000000" IDOrigen="___ignore___" IDDestino="___ignore___"/>
+				</cartaporte30:Mercancia>
+				<cartaporte30:Autotransporte NumPermisoSCT="DEMOPERMIT" PermSCT="TPAF10">
+					<cartaporte30:IdentificacionVehicular AnioModeloVM="2020" ConfigVehicular="T3S1" PlacaVM="ABC123" PesoBrutoVehicular="2.0"/>
+					<cartaporte30:Seguros AseguraRespCivil="DEMO INSURER" PolizaRespCivil="DEMO POLICY"/>
+					<cartaporte30:Remolques>
+						<cartaporte30:Remolque SubTipoRem="CTR003" Placa="trail1"/>
+					</cartaporte30:Remolques>
+				</cartaporte30:Autotransporte>
+			</cartaporte30:Mercancias>
+			<cartaporte30:FiguraTransporte>
+				<cartaporte30:TiposFigura TipoFigura="01" RFCFigura="VAAM130719H60" NumLicencia="a234567890" NombreFigura="Amigo Pedro">
+				</cartaporte30:TiposFigura>
+			</cartaporte30:FiguraTransporte>
+		</cartaporte30:CartaPorte>
+	<tfd:TimbreFiscalDigital xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital" xsi:schemaLocation="http://www.sat.gob.mx/TimbreFiscalDigital http://www.sat.gob.mx/sitio_internet/cfd/TimbreFiscalDigital/TimbreFiscalDigitalv11.xsd" Version="1.1" UUID="00000000-0000-0000-0000-000000000001" FechaTimbrado="2017-01-01T18:56:50" RfcProvCertif="___ignore___" SelloCFD="___ignore___"/>
+	</cfdi:Complemento>
+</cfdi:Comprobante>

--- a/jasman_delivery_guide/views/stock_picking_batch_views.xml
+++ b/jasman_delivery_guide/views/stock_picking_batch_views.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_picking_batch_form" model="ir.ui.view">
+        <field name="name">stock.picking.batch.view.form.inherit.jasman.delivery.guide</field>
+        <field name="model">stock.picking.batch</field>
+        <field name="inherit_id" ref="stock_picking_batch.stock_picking_batch_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="before">
+                <field name="l10n_mx_edi_is_cfdi_needed" invisible="1"/>
+                <field name="l10n_mx_edi_cfdi_state" invisible="1"/>
+                <field name="l10n_mx_edi_external_trade" invisible="1"/>
+                <field name="l10n_mx_edi_update_sat_needed" invisible="1"/>
+            </xpath>
+            <xpath expr="//header" position="inside">
+                <field name="is_delivery_guide_possible" invisible="1"/>
+                <button string="Generate Delivery Guide"
+                        name="l10n_mx_edi_action_send_batch_delivery_guide"
+                        type="object"
+                        invisible="not is_delivery_guide_possible or l10n_mx_edi_cfdi_state == 'sent'"/>
+                <button string="Cancel Delivery Guide"
+                        name="l10n_mx_edi_cfdi_try_cancel"
+                        type="object"
+                        invisible="not l10n_mx_edi_is_cfdi_needed or l10n_mx_edi_cfdi_state != 'sent'"/>
+                <button string="Update SAT"
+                        name="l10n_mx_edi_cfdi_try_sat"
+                        type="object"
+                        invisible="not l10n_mx_edi_update_sat_needed"/>
+            </xpath>
+            <xpath expr="//sheet//group/field[@name='scheduled_date']" position="after">
+                <field name="effective_date"/>
+            </xpath>
+            <xpath expr="//field[@name='picking_ids']" position="attributes">
+                <attribute name="default_order">'scheduled_date'</attribute>
+            </xpath>
+            <xpath expr="//notebook/page[@name='page_transfers']" position="after">
+                <page string="Additional Info" name="extra">
+                    <group string="Transport" name="mx_edi_group_transport">
+                        <field name="figure_ids" invisible="1"/>
+                        <field name="l10n_mx_edi_transport_type"/>
+                        <field name="l10n_mx_edi_vehicle_id"
+                               invisible="l10n_mx_edi_transport_type != '01'"
+                               required="l10n_mx_edi_transport_type == '01'"/>
+                        <field name="figure_id"
+                                invisible="l10n_mx_edi_transport_type != '01'"
+                                required="l10n_mx_edi_transport_type == '01'"/>
+                        <field name="l10n_mx_edi_distance"
+                               invisible="l10n_mx_edi_transport_type != '01'"
+                               required="l10n_mx_edi_transport_type == '01'"/>
+                   </group>
+                </page>
+                <page id="edi_documents" string="CFDI" name="page_cfdi" invisible="not l10n_mx_edi_document_ids">
+                    <field name="l10n_mx_edi_document_ids">
+                        <tree create="false" delete="false" edit="false" no_open="1">
+                            <field name="attachment_id" column_invisible="True" on_change="1"/>
+                            <field name="message" column_invisible="True"/>
+                            <field name="retry_button_needed" column_invisible="True"/>
+
+                            <field name="datetime"/>
+                            <field name="state" widget="l10n_mx_edi_document_state" on_change="1"/>
+                            <field name="sat_state" invisible="not sat_state" on_change="1"/>
+
+                            <button name="action_download_file" type="object" string="Download" invisible="not attachment_id"/>
+                            <button name="action_retry" type="object" string="Retry" invisible="not retry_button_needed"/>
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/jasman_delivery_guide/views/stock_picking_views.xml
+++ b/jasman_delivery_guide/views/stock_picking_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="vpicktree" model="ir.ui.view">
+        <field name="name">stock.picking.view.tree.inherit.jasman.delivery.guide</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.vpicktree"/>
+        <field name="arch" type="xml">
+            <field name="scheduled_date" position="after">
+                <field name="l10n_mx_edi_distance" optional="show"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Makes it possible to generate a Delivery Guide (Carta Porte) in a batch delivery order, instead of a single delivery order, since the customer normally groups several inter-warehouse transfers that are delivered through the same vehicle.
task-3776824